### PR TITLE
Add discord server as a category

### DIFF
--- a/template/partial/menu.tmpl
+++ b/template/partial/menu.tmpl
@@ -14,6 +14,7 @@
         <a href="{{.BaseURI}}upload/crackme" class="btn btn-link">Upload crackme</a>
         <a href="{{.BaseURI}}lasts/1" class="btn btn-link">Latest Crackmes</a> 
         <a href="{{.BaseURI}}faq" class="btn btn-link">Faq</a>
+        <a href="https://discord.gg/2pPV3yq" class="btn btn-link">Discord</a>
         <a href="{{.BaseURI}}user/{{.usersess}}" class="btn btn-link">Profile</a>
         <a href="{{.BaseURI}}logout" class="btn btn-link">Logout</a>
     </section>
@@ -31,6 +32,7 @@
                 <li class="nav"><a href="{{.BaseURI}}search" class="btn btn-link">Search</a>
                 <li class="nav"><a href="{{.BaseURI}}upload/crackme" class="btn btn-link">Upload crackme</a>
                 <li class="nav"><a href="{{.BaseURI}}lasts/1" class="btn btn-link">Latest Crackmes</a></li> 
+                <li class="nav"><a href="https://discord.gg/2pPV3yq" class="btn btn-link">Discord</a></li>
                 <li class="nav"><a href="{{.BaseURI}}faq" class="btn btn-link">Faq</a></li>
                 <li class="nav"><a href="{{.BaseURI}}user/{{.usersess}}" class="btn btn-link">Profile</a></li>
                 <li class="nav"><a href="{{.BaseURI}}logout" class="btn btn-link">Logout</a></li>
@@ -45,6 +47,7 @@
     <a href="{{.BaseURI}}search" class="btn btn-link">Search</a>
     <a href="{{.BaseURI}}lasts/1" class="btn btn-link">Latest Crackmes</a>
     <a href="{{.BaseURI}}faq" class="btn btn-link">Faq</a>
+    <a href="https://discord.gg/2pPV3yq" class="btn btn-link">Discord</a>
     <a href="{{.BaseURI}}login" class="btn btn-link">Login</a>
     <a href="{{.BaseURI}}register" class="btn btn-link">Register</a>
 </section>
@@ -61,6 +64,7 @@
             <li class="nav"><a href="{{.BaseURI}}search" class="btn btn-link">Search</a>
             <li class="nav"><a href="{{.BaseURI}}lasts/1" class="btn btn-link">Latest Crackmes</a></li>
             <li class="nav"><a href="{{.BaseURI}}faq" class="btn btn-link">Faq</a></li>
+            <li class="nav"><a href="https://discord.gg/2pPV3yq" class="btn btn-link">Discord</a></li>
             <li class="nav"><a href="{{.BaseURI}}login" class="btn btn-link">Login</a></li>
             <li class="nav"><a href="{{.BaseURI}}register" class="btn btn-link">Register</a></li>
         </ul>


### PR DESCRIPTION
This feature aims to add the discord server invite link as a category on the website since it's currently only available in the home page right now. 